### PR TITLE
Added windows support using win-spawn

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "node": ">=0.8.0"
   },
   "dependencies": {
-    "async": "~0.2.0"
+    "async":      "~0.2.0",
+    "win-spawn":  "2.0.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",

--- a/tasks/grunt-appengine.js
+++ b/tasks/grunt-appengine.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var path = require('path');
+var path  = require('path');
+var spawn = require('win-spawn');
 
 module.exports = function (grunt) {
 
@@ -24,7 +25,6 @@ module.exports = function (grunt) {
 
   function spawned(done, cmd, args, opts) {
     function spawnFunc() {
-      var spawn = require('child_process').spawn;
       spawn(cmd, args || [], opts || {}).on('exit', function (status) {
         done(status === 0);
       });


### PR DESCRIPTION
So turns out that on windows `child_process.spawn` doesn't use a shell and this makes starting python programs hard...

Luckily there is `win-spawn` which does the right thing. It `child_process.spawn` on Linux, so it's a drop-in replacement that only deals with the windows special case.
