### PR TITLE
Added the ability to pass in task target specific options 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
 before_install:
   - npm install -g grunt-cli

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ appengine: {
     }
   },
   frontend: {
-		root: 'frontend/'
+	  root: 'frontend/',
     options: {
       manageFlags: {
         version: '<%= pkg.version %>',

--- a/README.md
+++ b/README.md
@@ -41,9 +41,21 @@ appengine: {
       port: 8080
     }
   },
-  
   frontend: {
 		root: 'frontend/'
+    options: {
+      manageFlags: {
+        version: '<%= pkg.version %>',
+      }
+    }
+  },
+  staging: {
+    root: 'frontend/',
+    options: {
+      manageFlags: {
+        application: 'my-app-staging'
+      }
+    }
   },
   backend: {
   	root: 'backend/',
@@ -67,6 +79,11 @@ $ grunt appengine:run:frontend
 
 ```shell
 $ grunt appengine:update:frontend
+```
+
+**Update staging
+```shell
+$ grunt appengine:update:staging
 ```
 
 

--- a/tasks/grunt-appengine.js
+++ b/tasks/grunt-appengine.js
@@ -89,10 +89,12 @@ module.exports = function (grunt) {
 
       var gruntTaskTargetProfileOpts = grunt.config([name, target, profile]) || {};
       var gruntTaskTargetOpts = grunt.config([name, target]) || {};
+      var gruntTastTargetOptsExtra = gruntTaskTargetOpts.options || {};
       var gruntTaskOpts = grunt.config([name, 'options']) || {};
       var taskOpts = _.defaults(
         gruntTaskTargetProfileOpts,
         gruntTaskTargetOpts,
+        gruntTastTargetOptsExtra,
         gruntTaskOpts,
         defaultOpts
       );
@@ -113,6 +115,7 @@ module.exports = function (grunt) {
       var taskFlagsOpts = _.defaults(
         gruntTaskTargetProfileOpts[optsFlagsName] || {},
         gruntTaskTargetOpts[optsFlagsName] || {},
+        gruntTastTargetOptsExtra[optsFlagsName] || {},
         gruntTaskOpts[optsFlagsName] || {},
         defaultOpts[optsFlagsName] || {}
       );
@@ -158,6 +161,10 @@ module.exports = function (grunt) {
         if (attrval === true) {
           cmdFlags.push('--' + attrname);
         } else {
+          //TODO: break out to attrubuteValidator function 
+          if (attrname === 'version') {
+            attrval = attrval.replace(/\./g, '-');
+          }
           cmdFlags.push('--' + attrname + '=' + attrval);
         }
       }


### PR DESCRIPTION
gruntTaskTargetOpts was getting the target attributes. If you wanted to send target specific manageFlags to pass to an update. Also this nested options in the target, from what I have seen, seems like a grunt convention.
So I just passed in the target options object if it existed to the taskOpts.

See [updated example](https://github.com/justingrayston/grunt-appengine/tree/develop#usage-example) to see what I mean. This is useful to me, as on staging the app.yaml version is passed up (created from the current commit hash) and on live the pkg.version is used.

I figured it gives the end user a little more flexibility...
