### PR TITLE
Fixed broken tests

### DIFF
--- a/test/appengine_manage_test.js
+++ b/test/appengine_manage_test.js
@@ -57,12 +57,12 @@ exports.copy = {
   testUpdateWithCustomVersion: function (test) {
     var task = ctx.newTask(['update', 'myapp'], {
       manageFlags: {
-        version: '1.0'
+        version: '1-0'
       }
     });
 
     var result = task.execute(true);
-    test.equals(result.cmd, 'appcfg.py --version=1.0 --oauth2 update .');
+    test.equals(result.cmd, 'appcfg.py --version=1-0 --oauth2 update .');
 
     test.done();
   },

--- a/test/appengine_manage_test.js
+++ b/test/appengine_manage_test.js
@@ -57,7 +57,7 @@ exports.copy = {
   testUpdateWithCustomVersion: function (test) {
     var task = ctx.newTask(['update', 'myapp'], {
       manageFlags: {
-        version: '1-0'
+        version: '1.0'
       }
     });
 


### PR DESCRIPTION
It was the simple validation I added of the version number that was breaking the test. Comment in previsions email still valid I guess, but this will get it all passing.

Apologies once again, have a good Christmas.
